### PR TITLE
add timezone support for calendar

### DIFF
--- a/pinax/calendars/adapters.py
+++ b/pinax/calendars/adapters.py
@@ -3,6 +3,7 @@ import pytz
 
 from django.core.urlresolvers import reverse
 
+
 class EventAdapter(object):
     day_url_name = "daily"
     month_url_name = "monthly"

--- a/pinax/calendars/adapters.py
+++ b/pinax/calendars/adapters.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
+import pytz
 
 from django.core.urlresolvers import reverse
-
 
 class EventAdapter(object):
     day_url_name = "daily"
@@ -18,12 +18,13 @@ class EventAdapter(object):
     def month_url(self, year, month, **kwargs):
         return reverse(self.month_url_name, args=[year, month])
 
-    def events_by_day(self, year, month, **kwargs):
+    def events_by_day(self, year, month, tz, **kwargs):
         days = defaultdict(list)
         query_args = {
             "{}__year".format(self.date_field_name): year,
             "{}__month".format(self.date_field_name): month
         }
+        timezone = pytz.timezone(tz) if tz else pytz.utc
         for event in self.events.filter(**query_args).order_by(self.date_field_name):
-            days[getattr(event, self.date_field_name).day].append(event)
+            days[getattr(event, self.date_field_name).astimezone(timezone).day].append(event)
         return days

--- a/pinax/calendars/templatetags/pinax_calendars_tags.py
+++ b/pinax/calendars/templatetags/pinax_calendars_tags.py
@@ -37,7 +37,7 @@ def calendar(context, events, date=None, tz=None, **kwargs):
     next = events.month_url(plus_year, plus_month, **kwargs)
     prev = events.month_url(minus_year, minus_month, **kwargs)
 
-    events_by_day = events.events_by_day(date.year, date.month, **kwargs)
+    events_by_day = events.events_by_day(date.year, date.month, tz, **kwargs)
 
     title = "%s %s" % (cal.month_name[date.month], date.year)
 


### PR DESCRIPTION
While there is timezone support for 'today' and works well in day view, I found the dates on monthly view can be off since they are not timezone-aware. This pull-request makes sure if timezone is passed, it is respected in monthly view as well. 
